### PR TITLE
Update MiuiCamera repo path

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VENDOR_PATH := vendor/xiaomi/MiuiCamera
+VENDOR_PATH := vendor/MiuiCamera
 
 PRODUCT_COPY_FILES += \
     $(VENDOR_PATH)/system/etc/device_features/whyred.xml:system/etc/device_features/whyred.xml \


### PR DESCRIPTION
This fixes `error: 'vendor/xiaomi/MiuiCamera/system/etc/device_features/whyred.xml', needed...`
As the path is changed by this commit https://github.com/PixelExperience-Devices/device_xiaomi_whyred/commit/5bdc6f64993bac5f597bfa83a88d41c1f677a4af